### PR TITLE
css: Fix font URL

### DIFF
--- a/styles/sass/base/_base.scss
+++ b/styles/sass/base/_base.scss
@@ -1,5 +1,5 @@
 @font-face {
-  src: url("../../../fonts/HelveticaNeueCyr-Light.woff2") format("woff2");
+  src: url("../../fonts/HelveticaNeueCyr-Light.woff2") format("woff2");
   font-family: "HelveticaNeue-Light";
   font-display: swap;
 }


### PR DESCRIPTION
This fixes the resulting font URL to be `https://ktsirangelos.github.io/dida.studio/fonts/HelveticaNeueCyr-Light.woff2` from  `https://ktsirangelos.github.io/fonts/HelveticaNeueCyr-Light.woff2`.